### PR TITLE
feat: prometheus-metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -916,6 +916,9 @@ dependencies = [
  "hyper 0.14.32",
  "lazy_static",
  "lru 0.11.1",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "metrics-macros",
  "moka",
  "once_cell",
  "regex",
@@ -1922,6 +1925,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2346,6 +2350,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25dea7ac8057892855ec285c440160265225438c3c45072613c25a4b26e98ef5"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df88858cd28baaaf2cfc894e37789ed4184be0e1351157aec7bf3c2266c793fd"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.6",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.3",
+ "metrics",
+ "quanta",
+ "rand 0.9.1",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2703,6 +2765,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd1fe6824cea6538803de3ff1bc0cf3949024db3d43c9643024bfb33a807c0e"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +2957,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3436,6 +3531,12 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,9 @@ hex = "0.4.3"
 bincode = "2.0.1"
 base64 = "0.22.1"
 regex = "1.11.1"
+metrics = "0.24.2"
+metrics-macros = "0.7.1"
+metrics-exporter-prometheus = "0.17.0"
 
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -191,6 +191,62 @@ See `.github/workflows/release.yml` for cross-target examples.
 
 ---
 
+## 📊 Prometheus Metrics
+
+CacheBolt exposes Prometheus-compatible metrics at the `/metrics` endpoint on port `3000`. These metrics allow you to monitor request flow, latency thresholds, memory caching, and backend persistence.
+
+### Request Metrics
+
+- `cachebolt_proxy_requests_total{uri}`  
+  Total number of proxy requests received, labeled by URI.
+
+- `cachebolt_downstream_failures_total{uri}`  
+  Count of downstream request failures per URI.
+
+- `cachebolt_rejected_due_to_concurrency_total{uri}`  
+  Requests rejected due to max concurrency being exceeded.
+
+- `cachebolt_failover_total{uri}`  
+  Requests served via failover mode due to recent high latency.
+
+### In-Memory Cache Metrics
+
+- `cachebolt_memory_hits_total{uri}`  
+  Requests served directly from the in-memory cache.
+
+- `cachebolt_memory_store_total{uri}`  
+  Responses stored into the in-memory cache.
+
+- `cachebolt_memory_fallback_hits_total`  
+  Failover-mode requests served from memory cache.
+
+### Latency Monitoring
+
+- `cachebolt_proxy_request_latency_ms{uri}`  
+  Histogram of proxy request latency in milliseconds.
+
+- `cachebolt_latency_exceeded_ms{uri}`  
+  Histogram of requests whose latency exceeded the configured threshold.
+
+- `cachebolt_latency_exceeded_total{uri}`  
+  Count of latency threshold violations per URI.
+
+### Persistent Storage Metrics
+
+- `cachebolt_persist_attempts_total{backend}`  
+  Number of attempts to persist cache entries into the selected backend.
+
+- `cachebolt_persist_errors_total{backend}`  
+  Number of failed attempts to persist cache entries.
+
+- `cachebolt_persistent_fallback_hits_total`  
+  Requests served from persistent storage (GCS, S3, Azure, or local) during failover.
+
+- `cachebolt_fallback_miss_total`  
+  Count of failover attempts that missed both memory and persistent storage.
+
+---
+
 ## 📄 License
 
 Licensed under the [Apache License 2.0](./LICENSE).

--- a/config.yaml
+++ b/config.yaml
@@ -23,3 +23,4 @@ latency_failover:
 
 ignored_headers:
   - postman-token
+  - if-none-match


### PR DESCRIPTION
## 📈 Add Prometheus Metrics Instrumentation + README Updates

This pull request adds **Prometheus-based metrics** to the CacheBolt proxy, enabling robust observability and performance analysis.

### ✅ What's Included

- **New Prometheus metrics via `metrics` crate**:
  - **Request Flow**:
    - `cachebolt_proxy_requests_total{uri}`
    - `cachebolt_downstream_failures_total{uri}`
    - `cachebolt_rejected_due_to_concurrency_total{uri}`
    - `cachebolt_failover_total{uri}`
  - **In-Memory Cache**:
    - `cachebolt_memory_hits_total{uri}`
    - `cachebolt_memory_store_total{uri}`
    - `cachebolt_memory_fallback_hits_total`
  - **Latency Monitoring**:
    - `cachebolt_proxy_request_latency_ms{uri}`
    - `cachebolt_latency_exceeded_ms{uri}`
    - `cachebolt_latency_exceeded_total{uri}`
  - **Persistent Storage**:
    - `cachebolt_persist_attempts_total{backend}`
    - `cachebolt_persist_errors_total{backend}`
    - `cachebolt_persistent_fallback_hits_total`
    - `cachebolt_fallback_miss_total`

- **Instrumentation locations**:
  - `proxy_handler` logic (requests, latency, failovers)
  - `CACHE_WRITER` background task (persistence tracking)
  - `try_cache` logic (fallback paths)

- 📄 **README update** with a new `📊 Prometheus Metrics` section listing and describing all available metrics.
