### PR TITLE
Probabilistic Cache Refreshing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "metrics-macros",
  "moka",
  "once_cell",
+ "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
@@ -933,6 +934,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "tower 0.5.2",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,8 @@ metrics = "0.24.2"
 metrics-macros = "0.7.1"
 metrics-exporter-prometheus = "0.17.0"
 futures = "0.3"
-
+rand = "0.8"
+tower = "0.5.2"
 
 
 [dev-dependencies]

--- a/config.yaml
+++ b/config.yaml
@@ -1,26 +1,50 @@
+# 🔧 Unique identifier for this CacheBolt instance
 app_id: my-service
 
+# 🚦 Maximum number of concurrent outbound requests to the downstream service
 max_concurrent_requests: 200
+
+# 🌐 Base URL of the upstream API/backend to which requests are proxied
 downstream_base_url: http://localhost:4000
+
+# ⏱️ Timeout (in seconds) for downstream requests before failing
 downstream_timeout_secs: 5
 
-storage_backend: s3 # opciones: gcs, s3, azure, local
+# 💾 Backend used for persistent cache storage
+# Available options: gcs, s3, azure, local
+storage_backend: s3
+
+# 🪣 Name of the Google Cloud Storage bucket (used if storage_backend is 'gcs')
 gcs_bucket: cachebolt
+
+# 🪣 Name of the Amazon S3 bucket (used if storage_backend is 's3')
 s3_bucket: my-cachebolt-bucket
+
+# 📦 Name of the Azure Blob Storage container (used if storage_backend is 'azure')
 azure_container: cachebolt-container
 
+# 🧠 Memory cache configuration
+cache:
+  # 🚨 System memory usage threshold (%) above which in-memory cache will start evicting entries
+  memory_threshold: 80
 
-memory_eviction:
-  threshold_percent: 90
+  # 🔁 Percentage of requests (per key) that should trigger a refresh from backend instead of using cache
+  # Example: 10% means 1 in every 10 requests will bypass cache
+  refresh_percentage: 10
 
+# ⚠️ Latency-based failover configuration
 latency_failover:
-  default_max_latency_ms: 300
+  # ⌛ Default maximum allowed latency in milliseconds for any request
+  default_max_latency_ms: 3000
+
+  # 🛣️ Path-specific latency thresholds
   path_rules:
     - pattern: "^/api/v1/products/.*"
-      max_latency_ms: 150
+      max_latency_ms: 1500
     - pattern: "^/auth/.*"
-      max_latency_ms: 100
+      max_latency_ms: 1000
 
+# 🚫 List of request headers to ignore when computing cache keys (case-insensitive)
 ignored_headers:
   - postman-token
   - if-none-match

--- a/src/admin/clean.rs
+++ b/src/admin/clean.rs
@@ -1,3 +1,17 @@
+// Copyright (C) 2025 Matías Salinas (support@fenden.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::memory::memory::MEMORY_CACHE;
 use axum::{extract::Query, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,6 +192,7 @@ async fn main() {
     // ------------------------------------------------------
     let app = Router::new()
         .route("/metrics", get(move || async move { handle.render() }))
+        .route("/", get(proxy::proxy_handler)) 
         .route("/*path", get(proxy::proxy_handler))
         .route("/cache", delete(invalidate_handler));
 

--- a/src/memory/memory.rs
+++ b/src/memory/memory.rs
@@ -73,14 +73,14 @@ pub async fn load_into_memory(data: Vec<(String, CachedResponse)>) {
 /// Monitors system memory usage and evicts LRU entries if usage exceeds the configured threshold.
 /// This function is designed to prevent the application from consuming too much system memory.
 ///
-/// The threshold is defined in `config.yaml` under `memory_eviction.threshold_percent`.
+/// The threshold is defined in `config.yaml` under `cache.memory_threshold`.
 ///
 /// # Arguments
 /// * `cache` - A mutable reference to the global LRU cache to perform eviction on.
 pub async fn maybe_evict_if_needed(cache: &mut LruCache<String, CachedResponse, RandomState>) {
     let config = CONFIG.get();
     let threshold_percent = config
-        .map(|c| c.memory_eviction.threshold_percent)
+        .map(|c| c.cache.memory_threshold)
         .unwrap_or(80);
 
     let (used_kib, total_kib) = get_memory_usage_kib();

--- a/src/rules/latency.rs
+++ b/src/rules/latency.rs
@@ -32,7 +32,7 @@ pub fn should_failover(uri: &str) -> bool {
     let now = Instant::now();
     let map = LATENCY_FAILS.read().unwrap();
     if let Some(&last_fail) = map.get(&key) {
-        now.duration_since(last_fail) < Duration::from_secs(300)
+        now.duration_since(last_fail) < Duration::from_secs(10)
     } else {
         false
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 pub mod latency;
+pub mod refresh;

--- a/src/rules/refresh.rs
+++ b/src/rules/refresh.rs
@@ -1,0 +1,48 @@
+// Copyright (C) 2025 Matías Salinas (support@fenden.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::config::CONFIG;
+use tracing::{info, debug};
+
+/// Global hit counters for probabilistic refresh logic
+static REFRESH_COUNTERS: Lazy<Mutex<HashMap<String, u64>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Determines if a response should bypass cache and refresh from backend
+pub fn should_refresh(key: &str) -> bool {
+    let percentage = CONFIG.get().map(|c| c.cache.refresh_percentage).unwrap_or(0);
+
+    if percentage == 0 {
+        return false;
+    }
+
+    let mut counters = REFRESH_COUNTERS.lock().unwrap();
+    let counter = counters.entry(key.to_string()).or_insert(0);
+    *counter += 1;
+
+    let modulus = 100 / percentage.max(1);
+    let should = *counter % modulus as u64 == 0;
+
+    if should {
+        info!("🔄 Refresh triggered for key '{}' after {} hits", key, counter);
+    } else {
+        debug!("⏩ No refresh for key '{}', current count {}", key, counter);
+    }
+
+    should
+}

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -14,7 +14,7 @@
 
 #[cfg(test)]
 pub mod tests {
-    use cachebolt::config::{Config, LatencyFailover, MemoryEviction, StorageBackend, CONFIG};
+    use cachebolt::config::{Config, LatencyFailover, CacheSettings, StorageBackend, CONFIG};
     use std::env;
     use std::fs::write;
 
@@ -33,8 +33,9 @@ azure_container: test-azure
 max_concurrent_requests: 10
 downstream_base_url: http://localhost
 downstream_timeout_secs: 5
-memory_eviction:
-  threshold_percent: 75
+cache:
+  memory_threshold: 75
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 300
   path_rules:
@@ -48,7 +49,7 @@ storage_backend: s3
         let config = Config::from_file(&path).expect("should parse valid config");
 
         assert_eq!(config.app_id, "testapp");
-        assert_eq!(config.memory_eviction.threshold_percent, 75);
+        assert_eq!(config.cache.memory_threshold, 75);
         assert_eq!(config.latency_failover.default_max_latency_ms, 300);
         assert_eq!(config.latency_failover.path_rules.len(), 1);
         assert_eq!(config.storage_backend, StorageBackend::S3);
@@ -63,9 +64,9 @@ s3_bucket: test-s3
 azure_container: test-azure
 max_concurrent_requests: 5
 downstream_base_url: http://localhost
-downstream_timeout_secs: 10
-memory_eviction:
-  threshold_percent: 70
+cache:
+  memory_threshold: 75
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 200
   path_rules: []
@@ -88,8 +89,9 @@ azure_container: test-azure
 max_concurrent_requests: 3
 downstream_base_url: http://localhost
 downstream_timeout_secs: 2
-memory_eviction:
-  threshold_percent: 85
+cache:
+  memory_threshold: 75
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 150
   path_rules: []
@@ -113,8 +115,9 @@ azure_container: b3
 max_concurrent_requests: 1
 downstream_base_url: http://x
 downstream_timeout_secs: 1
-memory_eviction:
-  threshold_percent: 60
+cache:
+  memory_threshold: 75
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 100
   path_rules: []
@@ -137,8 +140,9 @@ storage_backend: azure
             max_concurrent_requests: 1,
             downstream_base_url: "http://x".into(),
             downstream_timeout_secs: 2,
-            memory_eviction: MemoryEviction {
-                threshold_percent: 90,
+            cache: CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10,
             },
             latency_failover: LatencyFailover {
                 default_max_latency_ms: 200,
@@ -151,7 +155,7 @@ storage_backend: azure
         CONFIG.get_or_init(|| config);
 
         let actual = CONFIG.get().unwrap();
-        assert_eq!(actual.memory_eviction.threshold_percent, 90);
+        assert_eq!(actual.cache.memory_threshold, 90);
         assert_eq!(actual.storage_backend, StorageBackend::Local);
     }
 

--- a/tests/test_main.rs
+++ b/tests/test_main.rs
@@ -42,8 +42,9 @@ azure_container: test-az
 max_concurrent_requests: 10
 downstream_base_url: http://localhost
 downstream_timeout_secs: 5
-memory_eviction:
-  threshold_percent: 85
+cache:
+  memory_threshold: 80
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 250
   path_rules:
@@ -55,7 +56,7 @@ storage_backend: s3
         let cfg = Config::from_file(&path).expect("Config should parse");
 
         assert_eq!(cfg.app_id, "test-app");
-        assert_eq!(cfg.memory_eviction.threshold_percent, 85);
+        assert_eq!(cfg.cache.memory_threshold, 80);
         assert_eq!(cfg.latency_failover.path_rules.len(), 1);
         assert_eq!(cfg.storage_backend, StorageBackend::S3);
     }
@@ -70,8 +71,9 @@ azure_container: unused
 max_concurrent_requests: 10
 downstream_base_url: http://localhost
 downstream_timeout_secs: 5
-memory_eviction:
-  threshold_percent: 70
+cache:
+  memory_threshold: 80
+  refresh_percentage: 10
 latency_failover:
   default_max_latency_ms: 100
   path_rules: []

--- a/tests/test_memory.rs
+++ b/tests/test_memory.rs
@@ -16,7 +16,7 @@
 mod tests {
     use super::*;
     use cachebolt::{
-        config::{Config, LatencyFailover, MaxLatencyRule, MemoryEviction, StorageBackend, CONFIG},
+        config::{CacheSettings, Config, LatencyFailover, MaxLatencyRule, StorageBackend, CONFIG},
         memory::memory::{get_from_memory, get_memory_usage_kib, load_into_memory, maybe_evict_if_needed, CachedResponse, MEMORY_CACHE},
     };
     use bytes::Bytes;
@@ -36,8 +36,9 @@ mod tests {
             max_concurrent_requests: 1,
             downstream_base_url: "http://localhost".into(),
             downstream_timeout_secs: 1,
-            memory_eviction: MemoryEviction {
-                threshold_percent: threshold,
+            cache: CacheSettings {
+                memory_threshold: threshold,
+                refresh_percentage: 10, // Set a default refresh percentage
             },
             latency_failover: LatencyFailover {
                 default_max_latency_ms: 200,

--- a/tests/test_proxy.rs
+++ b/tests/test_proxy.rs
@@ -104,8 +104,9 @@ mod tests {
             max_concurrent_requests: 1,
             downstream_base_url: "http://127.0.0.1:9999".into(),
             downstream_timeout_secs: 1,
-            memory_eviction: cachebolt::config::MemoryEviction {
-                threshold_percent: 90,
+            cache: cachebolt::config::CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10,
             },
             latency_failover: cachebolt::config::LatencyFailover {
                 default_max_latency_ms: 1000,
@@ -156,8 +157,9 @@ mod tests {
             max_concurrent_requests: 1,
             downstream_base_url: "http://127.0.0.1:9999".into(), // puerto inválido
             downstream_timeout_secs: 1,
-            memory_eviction: cachebolt::config::MemoryEviction {
-                threshold_percent: 90,
+            cache: cachebolt::config::CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10,
             },
             latency_failover: cachebolt::config::LatencyFailover {
                 default_max_latency_ms: 1000,
@@ -187,8 +189,9 @@ mod tests {
             max_concurrent_requests: 1,
             downstream_base_url: "http://127.0.0.1:9999".into(),
             downstream_timeout_secs: 1,
-            memory_eviction: cachebolt::config::MemoryEviction {
-                threshold_percent: 90,
+            cache: cachebolt::config::CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10,
             },
             latency_failover: cachebolt::config::LatencyFailover {
                 default_max_latency_ms: 1000,

--- a/tests/test_rules.rs
+++ b/tests/test_rules.rs
@@ -14,15 +14,13 @@
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use cachebolt::config::{
-        CONFIG, Config, LatencyFailover, MaxLatencyRule, MemoryEviction, StorageBackend,
+        CacheSettings, Config, LatencyFailover, MaxLatencyRule, StorageBackend, CONFIG
     };
     use cachebolt::rules::latency::{
         LATENCY_FAILS, get_max_latency_for_path, mark_latency_fail, should_failover,
     };
     use ctor::ctor;
-    use once_cell::sync::OnceCell;
     use regex::Regex;
     use std::thread::sleep;
     use std::time::{Duration, Instant};
@@ -50,8 +48,9 @@ mod tests {
             max_concurrent_requests: 10,
             downstream_base_url: "http://localhost".into(),
             downstream_timeout_secs: 5,
-            memory_eviction: MemoryEviction {
-                threshold_percent: 90,
+            cache: CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10, // Set a default refresh percentage
             },
             storage_backend: StorageBackend::Local,
             ignored_headers: None,
@@ -97,8 +96,9 @@ mod tests {
             max_concurrent_requests: 10,
             downstream_base_url: "http://localhost".into(),
             downstream_timeout_secs: 5,
-            memory_eviction: MemoryEviction {
-                threshold_percent: 90,
+            cache: CacheSettings {
+                memory_threshold: 90,
+                refresh_percentage: 10, // Set a default refresh percentage
             },
             storage_backend: StorageBackend::Local,
             ignored_headers: None,

--- a/tests/test_storage.rs
+++ b/tests/test_storage.rs
@@ -17,7 +17,7 @@
 mod tests {
     use super::*;
     use cachebolt::config::{
-        CONFIG, Config, LatencyFailover, MaxLatencyRule, MemoryEviction, StorageBackend,
+        CacheSettings, Config, LatencyFailover, MaxLatencyRule, StorageBackend, CONFIG
     };
     use cachebolt::storage::local::*;
     use std::fs;
@@ -41,8 +41,9 @@ mod tests {
                 max_concurrent_requests: 10,
                 downstream_base_url: "http://localhost".to_string(),
                 downstream_timeout_secs: 5,
-                memory_eviction: MemoryEviction {
-                    threshold_percent: 80,
+                cache: CacheSettings {
+                    memory_threshold: 90,
+                    refresh_percentage: 10, // Set a default refresh percentage
                 },
                 latency_failover: LatencyFailover {
                     default_max_latency_ms: 200,


### PR DESCRIPTION
This PR introduces support for probabilistic cache refreshing in CacheBolt. It allows a configurable percentage of requests to bypass the cache and trigger a fresh fetch from the upstream backend.

✨ New Configuration
```yaml
cache:
  refresh_percentage: 10
```
Affects memory and persistent cache behavior.

Ensures long-lived cached entries are periodically refreshed without manual invalidation.

Controlled via a per-key counter and uniform modulus logic.

📈 Metrics Added
cachebolt_memory_hits_total now excludes refresh-triggered hits.

New tracing logs for refresh activation and key hit counts.

🔧 Additional Notes
Backward compatible: if refresh_percentage is not set or is 0, behavior remains unchanged.

Integrated directly into the main proxy flow, before memory or fallback logic.